### PR TITLE
Add color palette in scss

### DIFF
--- a/app/assets/less/_colorPalette.less
+++ b/app/assets/less/_colorPalette.less
@@ -1,0 +1,29 @@
+// brand color palette
+@pc-color-white: #fff;
+@pc-color-black: #000;
+@pc-color-blue-pearson: #007fa3;
+@pc-color-blue-midnight: #003057;
+@pc-color-blue-ice: #d4eae4;
+@pc-color-blue-ink: #005a70;
+@pc-color-turquoise-marine: #12b2a6;
+@pc-color-green-lime: #d2db0e;
+@pc-color-green-grass: #008638;
+@pc-color-green-fresh: #84bd00;
+@pc-color-purple-royal: #9e007e;
+@pc-color-pink-hot: #ea067e;
+@pc-color-red-strawberry: #db0020;
+@pc-color-orange-juicy: #ea7600;
+@pc-color-yellow-sunshine: #ffb81c;
+@pc-color-gray-graphite: #505759;
+
+// digital colors
+@pc-color-blue-digital: #047a9c;
+@pc-color-green-tealish: #22b6b4;
+@pc-color-green-tealish-shade: #bce9e8;
+@pc-color-white-cool: #f5f5f5;
+@pc-color-white-warm: #ececec;
+@pc-color-gray-cool: #d3d3d3;
+@pc-color-gray-pencil: #74797b;
+@pc-color-gray-pencil-hb: #636769;
+@pc-color-gray-charcoal: #393c3d;
+@pc-color-black-soft: #252525;

--- a/app/assets/scss/_colorPalette.scss
+++ b/app/assets/scss/_colorPalette.scss
@@ -1,0 +1,29 @@
+// brand color palette
+$pc-color-white: #fff !default;
+$pc-color-black: #000 !default;
+$pc-color-blue-pearson: #007fa3 !default;
+$pc-color-blue-midnight: #003057 !default;
+$pc-color-blue-ice: #d4eae4 !default;
+$pc-color-blue-ink: #005a70 !default;
+$pc-color-turquoise-marine: #12b2a6 !default;
+$pc-color-green-lime: #d2db0e !default;
+$pc-color-green-grass: #008638 !default;
+$pc-color-green-fresh: #84bd00 !default;
+$pc-color-purple-royal: #9e007e !default;
+$pc-color-pink-hot: #ea067e !default;
+$pc-color-red-strawberry: #db0020 !default;
+$pc-color-orange-juicy: #ea7600 !default;
+$pc-color-yellow-sunshine: #ffb81c !default;
+$pc-color-gray-graphite: #505759 !default;
+
+// digital colors
+$pc-color-blue-digital: #047a9c !default;
+$pc-color-green-tealish: #22b6b4 !default;
+$pc-color-green-tealish-shade: #bce9e8 !default;
+$pc-color-white-cool: #f5f5f5 !default;
+$pc-color-white-warm: #ececec !default;
+$pc-color-gray-cool: #d3d3d3 !default;
+$pc-color-gray-pencil: #74797b !default;
+$pc-color-gray-pencil-hb: #636769 !default;
+$pc-color-gray-charcoal: #393c3d !default;
+$pc-color-black-soft: #252525 !default;

--- a/app/assets/stylus/_colorPalette.styl
+++ b/app/assets/stylus/_colorPalette.styl
@@ -1,0 +1,29 @@
+// brand color palette
+$pc-color-white = white
+$pc-color-black = black
+$pc-color-blue-pearson = #007fa3
+$pc-color-blue-midnight = #003057
+$pc-color-blue-ice = #d4eae4
+$pc-color-blue-ink = #005a70
+$pc-color-turquoise-marine = #12b2a6
+$pc-color-green-lime = #d2db0e
+$pc-color-green-grass = #008638
+$pc-color-green-fresh = #84bd00
+$pc-color-purple-royal = #9e007e
+$pc-color-pink-hot = #ea067e
+$pc-color-red-strawberry = #db0020
+$pc-color-orange-juicy = #ea7600
+$pc-color-yellow-sunshine = #ffb81c
+$pc-color-gray-graphite = #505759
+
+// digital colors
+$pc-color-blue-digital = #047a9c
+$pc-color-green-tealish = #22b6b4
+$pc-color-green-tealish-shade = #bce9e8
+$pc-color-white-cool = whitesmoke
+$pc-color-white-warm = #ececec
+$pc-color-gray-cool = lightgray
+$pc-color-gray-pencil = #74797b
+$pc-color-gray-pencil-hb = #636769
+$pc-color-gray-charcoal = #393c3d
+$pc-color-black-soft = #252525


### PR DESCRIPTION
* `pc-` is prefix from: `Pearson Convergence `. We use same prefix for common components in PEF/Pulse.
* `// brand color palette` is taken from https://brand.pearson.com/brand-toolkit/assets-templates.html
* `// digital colors` is taken from https://pearson.invisionapp.com/boards/R71I3OGTZWV36#/2524192