### PR TITLE
Fix shorthand hex to hex

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,9 @@ module.exports = (grunt) => {
         data: pc_colors,
         helpers: {
             toHex: function (hexColor) {
-              if (hexColor.length === 4 ) {
-                hexColor =  '#' + hexColor.substr(1).repeat(2);
+              // #fc0 to #ffcc00
+              if (hexColor.length === 4) {
+                hexColor = hexColor.replace( /\#(\w)(\w)(\w)/, "#$1$1$2$2$3$3");
               }
 
               return hexColor.toUpperCase();


### PR DESCRIPTION
Previous version replace `#fc0` with `#fc0fc0`. 
Should be `#ffcc00`